### PR TITLE
Likely fix for #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "homepage": "https://github.com/TheLarkInn/V8LazyParseWebpackPlugin#readme",
   "devDependencies": {
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "^2.1.0-beta.22"
+  },
+  "dependencies": {
     "webpack-sources": "^0.1.2"
   }
 }


### PR DESCRIPTION
It seems like `webpack-sources` should be a `dependency`.